### PR TITLE
Only check for installed packages in the bootstrap directory

### DIFF
--- a/workers/installPkgDeps.R
+++ b/workers/installPkgDeps.R
@@ -76,9 +76,9 @@ if (Sys.info()['sysname'] == "Darwin")
 
 
 ap <- available.packages(contrib.url(biocinstallRepos()[c("CRAN", "BioCsoft")]))
-ip <- rownames(installed.packages())
+ip <- rownames(installed.packages(lib.loc = bootstrap_libdir))
 bootstrap_pkgs <- c("graph", "biocViews", "knitr", "knitrBootstrap",
-    "BiocCheck", "devtools", "codetools", "httr")
+    "devtools", "codetools", "httr", "curl")
 
 for (pkg in bootstrap_pkgs)
 {


### PR DESCRIPTION
Also add curl to the list of boostrap packages.

Fixes #13
