### PR TITLE
Don't link directly to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The message sent to SPB contains a flag indicating that this build was
 originated by the SPB.
 
 When the build is complete, another script on staging
-(https://github.com/Bioconductor/packagebuilder/blob/master/spb_history/track_build_completion.py)
+[track_build_completion.py](spb_history/track_build_completion.py)
 is listening, and it posts a message to the tracker
 (using an HTTPS request) including a link to the build report.
 


### PR DESCRIPTION
We can be more portable using relative paths.

Notice, this works fine, just as in : https://github.com/Bioconductor/packagebuilder/commit/bf8fca7aeb4b5c412a3da0d78aca65296230c77c#diff-04c6e90faac2675aa89e2176d2eec7d8R111

FYI
cc/ @dtenenba @jimhester 
